### PR TITLE
Adds a public interface for the Sample tick

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -405,6 +405,11 @@ impl Sample {
         }
     }
 
+    /// Get the current tick
+    pub fn tick(&self) -> i32 {
+        self.tick
+    }
+
     ///
     /// Check if a given variable is available in the telemetry sample
     pub fn has(&self, name: &'static str) -> bool {


### PR DESCRIPTION
This allows users of the library to keep track of the current tick number, and potentially check for missed ticks.